### PR TITLE
Removes desktop sharing notice

### DIFF
--- a/SpeakerPresentation List
+++ b/SpeakerPresentation List
@@ -1,6 +1,6 @@
 # Day 1
 
-Day 1 will happen on Candle's Jitsi server, we still have to sort out desktop sharing because it is bugged for some reason.
+Day 1 will happen on Candle's Jitsi server.
 
 [Time meant in GMT+1]
 19:00 - Introduction to #PlebSec & Agenda


### PR DESCRIPTION
As you now have figured out that your browser extension prevented it from working.